### PR TITLE
Minor readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ composer create-project fourkitchens/sous-drupal-project PROJECT_NAME --no-inter
 ### Install custom theme & project module
 
 Install your theme
-- Follow the theme's setup instructions found in `/web/themes/contrib/emulsify-desig-system`
+- Follow the theme's setup instructions found in `/web/themes/contrib/emulsify-design-system`
 - Recommended naming for the theme is `/web/themes/custom/PROJECT_NAME`
 
 Create a new project module

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Import a copy of the canonical database backup into your local instance. This as
 **local-data-bak**
 
 ```
-yarn local-data-back
+yarn local-data-bak
 ```
 
 Create a local database backup. Saves the backup to the `./reference` directory.

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ composer create-project fourkitchens/sous-drupal-project PROJECT_NAME --no-inter
 ### Install custom theme & project module
 
 Install your theme
-- Follow the theme's setup instructions found in `/web/themes/contrib/emulsify-desig-system` 
+- Follow the theme's setup instructions found in `/web/themes/contrib/emulsify-desig-system`
 - Recommended naming for the theme is `/web/themes/custom/PROJECT_NAME`
 
 Create a new project module
-Generate a custom module at `/web/modules/custom/PROJECT_NAME` using drupal console. 
+Generate a custom module at `/web/modules/custom/PROJECT_NAME` using drupal console.
 Follow the documentation for the generate:module command [here](https://hechoendrupal.gitbooks.io/drupal-console/en/commands/generate-module.html)
 
 
 ### Install Sous Drupal
 
-Get a local environment oporating. You can use the included lando configuration. Requires [Lando](https://docs.lando.dev/basics/installation.html#system-requirements) 
+Get a local environment oporating. You can use the included lando configuration. Requires [Lando](https://docs.lando.dev/basics/installation.html#system-requirements)
 
 ```
 lando start
@@ -76,7 +76,7 @@ yarn local-data-back
 
 Create a local database backup. Saves the backup to the `./reference` directory.
 
-**confex**
+**rebuild**
 
 ```
 yarn rebuild


### PR DESCRIPTION
- Updates the "rebuild" command heading (was "confex" before)
- Updates the local data backup example in the readme

_(And apparently my editor removed unnecessary spaces at the end of lines)_