### PR TITLE
feat: add build-theme command to sous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ example.sites.php
 default.services.yml
 default.settings.php
 settings.php
+web/themes/custom/emulsify

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         }
     },
     "scripts": {
-        "post-create-project-cmd": "Sous\\Starter::installTheme"
+        "post-create-project-cmd": "Sous\\Starter::installTheme",
+        "install-theme": "Sous\\Starter::installTheme"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,6 @@
         }
     },
     "scripts": {
-        "post-create-project-cmd": "Sous\\Starter::installTheme",
-        "install-theme": "Sous\\Starter::installTheme"
+        "post-create-project-cmd": "Sous\\Starter::installTheme"
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "confex": "./scripts/sous/confex.sh",
     "import-data": "./scripts/sous/import-data.sh",
     "rebuild": "./scripts/sous/rebuild.sh",
-    "local-data-bak": "./scripts/sous/local-data-bak.sh"
+    "local-data-bak": "./scripts/sous/local-data-bak.sh",
+    "build-theme": "./scripts/sous/build-theme.sh"
   }
 }

--- a/scripts/sous/build-theme.sh
+++ b/scripts/sous/build-theme.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd web/themes/custom/emulsify
+yarn
+yarn build
+yarn build-storybook

--- a/scripts/sous/rebuild.sh
+++ b/scripts/sous/rebuild.sh
@@ -3,4 +3,5 @@
 composer install
 yarn import-data
 yarn confim
+yarn build-theme
 lando drush uli

--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -22,8 +22,8 @@ public static function installTheme() {
   $drupalFinder->locateRoot(getcwd());
   $composerRoot = str_replace('-', '_', strtolower(basename($drupalFinder->getComposerRoot())));
   // Execute the Emulsify theme build based on composer create path.
-  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && php emulsify.php $composerRoot");
-  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && npm install");
+  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && php emulsify.php emulsify");
+  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && yarn");
   // Generate  system.theme.yml and append new theme to install.
   $system_theme_yml = [
     "default" => $composerRoot,
@@ -31,6 +31,6 @@ public static function installTheme() {
   ];
   $yaml = Yaml::dump($system_theme_yml);
   file_put_contents('web/profiles/contrib/sous/config/install/system.theme.yml', $yaml);
-  file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$composerRoot.PHP_EOL, FILE_APPEND | LOCK_EX);
+  file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - emulsify'.PHP_EOL, FILE_APPEND | LOCK_EX);
   }
 }


### PR DESCRIPTION
## Purpose:
- Allow devs to build the theme from the project root

## Issues:
- Closes: #16 

## Notes:
- This changes the name of the default theme from being the same name as the project directory to being a hard coded "emulsify", this makes sense to me but am curious to hear from others.  I know we could have a naming collision with a module named "emulsify" but that seems avoidable.