### PR TITLE
fix: correct path for emulsify install

### DIFF
--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -22,8 +22,9 @@ public static function installTheme() {
   $drupalFinder->locateRoot(getcwd());
   $composerRoot = str_replace('-', '_', strtolower(basename($drupalFinder->getComposerRoot())));
   // Execute the Emulsify theme build based on composer create path.
-  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && php emulsify.php $composerRoot");
-  shell_exec ("cd web/themes/contrib/emulsify-design-system/ && npm install");
+  shell_exec ("cd web/themes/contrib/emulsify-drupal/ && php emulsify.php $composerRoot");
+  shell_exec ("cd web/themes/contrib/emulsify-drupal/ && npm install");
+  shell_exec ("cd web/themes/custom/$composerRoot/ && npm install");
   // Generate  system.theme.yml and append new theme to install.
   $system_theme_yml = [
     "default" => $composerRoot,


### PR DESCRIPTION
## Purpose:
Fixes the issue -
Receiving error when install is performing theme install:
`sh: line 0: cd: web/themes/contrib/emulsify-design-system/: No such file or directory`

## Issues:
- Closes: https://www.drupal.org/project/sous/issues/3199022
