### PR TITLE
feat: Update php to 7.4

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: sous-project
 recipe: drupal9
 config:
   webroot: web
-  php: '7.3'
+  php: "7.4"
 services:
   appserver:
     run:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "fourkitchens/sous-drupal-distro": "2.x-dev",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",


### PR DESCRIPTION
### Purpose:
- Updates lando config to php 7.4

### Notes:
- https://en.wikipedia.org/wiki/PHP
- PHP 7.4 is the latest and last major version of PHP7. It will be supported until the end of 2022.
- PHP 7.4 is the default version of PHP on drupal specific hosts like Acquia and Pantheon so issues with compatibility shouldn't be a concern.

### Testing:
- [x] Set up a new local project. 
- [x] Once lando is set up run `lando php -v` and verify php is running `7.4.*`