### PR TITLE
feat: set the admin theme to claro

### DIFF
--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -27,7 +27,7 @@ public static function installTheme() {
   // Generate  system.theme.yml and append new theme to install.
   $system_theme_yml = [
     "default" => $composerRoot,
-    "admin"=> "thunder_admin"
+    "admin"=> "claro"
   ];
   $yaml = Yaml::dump($system_theme_yml);
   file_put_contents('web/profiles/contrib/sous/config/install/system.theme.yml', $yaml);


### PR DESCRIPTION
### Purpose:
- Sets the admin theme to Claro during install. See: https://github.com/fourkitchens/sous-drupal-distro/pull/25