### PR TITLE
Feature Set Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 This will provide you with a starting Drupal project that is managed with Composer. The install will include a small set of contrib modules, a starting custom module for specific for the build, and a custom starting theme generated from Emulsify.
 
+## Features and Configurations
+
+Sous not only generates a custom theme based on Emulsify it also builds upon Drupal's default configuration to help streamline the project setup process. See the feature set documentation [here](docs/features.md).
 
 ## Composer Install
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,26 @@
+[![Sous](https://circleci.com/gh/fourkitchens/sous-drupal-project.svg?style=svg)](https://app.circleci.com/github/fourkitchens/sous-drupal-project/pipelines)
+
+# Features and Configurations
+
+## Emulsify
+
+## Content types
+
+## Media
+
+## Content Authoring
+
+### Paragraphs
+
+### Entity Browsers
+
+### Text Formatting
+
+The following text formats come bundled with Drupal's default installation profile. Sous builds upon these defaults and gives them distinct configuration for specific purposes.
+
+- **Full HTML Filter**: An unrestricted filter that only corrects broken html and removes empty `p` tags when rendered.
+- **Basic HTML Filter**: General use filter that offers a broad range of formatting options. Ideal for most instances of formatted text.
+- **Restricted HTML Filter**: Limited access filter best used for specific scenarios where some formatting is appropriate.
+- **Plain Text Filter**: Rendered as a raw string.
+
+## User Roles and Permissions


### PR DESCRIPTION
## Purpose:
- Add documentation to the sous project that describes the features and configuration that go beyond Drupal's default installation.

## Testing:
- [ ] Review readme and new `docs` directory. Verify it accurately describes Sous's customization to a standard drupal install. 