### PR TITLE
fix: missing commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1",
   "description": "A starter kit for a Drupal project",
   "scripts": {
+    "confim": "./scripts/sous/confim.sh",
+    "confex": "./scripts/sous/confex.sh",
+    "import-data": "./scripts/sous/import-data.sh",
+    "rebuild": "./scripts/sous/rebuild.sh",
+    "local-data-bak": "./scripts/sous/local-data-bak.sh",
     "publish": "semantic-release --tag-format '${version}'",
     "publish-test": "semantic-release --tag-format '${version}' --dry-run --debug",
     "postinstall": "patch-package"


### PR DESCRIPTION
# Purpose
- fix: missing commands

# Description:
This commit accidentally wiped out the package.json commands: https://github.com/fourkitchens/sous-drupal-project/commit/600ec91995188c170fab8aa620f9fde84e2f61d8, this PR adds them back.