### PR TITLE
fix: swap distro from github to drupal.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,21 +9,15 @@
             "url": "https://packages.drupal.org/8"
         },
         {
-            "type": "vcs",
-            "url": "git@github.com:fourkitchens/sous-drupal-distro.git"
-        },
-        {
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "fourkitchens/sous-drupal-distro": "2.x-dev",
+        "drupal/sous": "2.3.0",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",
-        "drupal/console": "^1.9.7",
-        "drupal/core-recommended": "^9",
+        "drupal/core-recommended": "^9.2.6",
         "drupal/core-composer-scaffold": "^9",
         "drush/drush": "^10.0",
         "vlucas/phpdotenv": "^2.4",


### PR DESCRIPTION
## WIP
- This is currently broken, composer won't install, for some reason when we pull the distro from drupal.org it tries to install Drupal core 8.x instead of 9.x.