### PR TITLE
Change the admin theme to Gin and remove Claro

### DIFF
--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -29,7 +29,7 @@ public static function installTheme() {
   // Generate  system.theme.yml and append new theme to install.
   $system_theme_yml = [
     "default" => $composerRoot,
-    "admin"=> "claro"
+    "admin"=> "gin"
   ];
   $yaml = Yaml::dump($system_theme_yml);
   file_put_contents('web/profiles/contrib/sous/config/install/system.theme.yml', $yaml);


### PR DESCRIPTION
This PR does the following:

- Removed support for the [Claro Admin theme](https://www.drupal.org/project/claro/)
- Installs the [Gin admin theme](https://www.drupal.org/project/gin)
- Notes:

- Gin is a new core theme with a rigorously tested design system: https://www.drupal.org/docs/8/core/themes/gin-theme/design.
- Accessibility is a driving focus of gin.
- The color palette is fairly neutral.
- Support and bug fixes will be bundled with core updates.