### PR TITLE
fix: distro version and find-and-replace command for linux

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "fourkitchens/sous-drupal-distro": "dev-4.x-beta",
+        "fourkitchens/sous-drupal-distro": "4.x-dev",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",
         "drupal/console": "^1.9.7",

--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -20,8 +20,9 @@ public static function installTheme() {
   // New DrupalFinder to get the Composer root path.
   $drupalFinder = new DrupalFinder();
   $drupalFinder->locateRoot(getcwd());
-  $removeChars = array("-", ".", "_", " ");
-  $composerRoot = str_replace($removeChars, '', strtolower(basename($drupalFinder->getComposerRoot())));
+  $removeChars = array("-", ".", " ");
+  $composerRoot = str_replace($removeChars, '_', strtolower(basename($drupalFinder->getComposerRoot())));
+  $dashed_project_name = str_replace('_', '-', $composerRoot);
   // Install node dependencies which include EmulsifyCLI for commands below.
   shell_exec ('[ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh" && nvm install lts/gallium && nvm use && npm ci');
   // Execute the Emulsify theme build based on composer create path.
@@ -37,6 +38,6 @@ public static function installTheme() {
   file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$composerRoot.PHP_EOL, FILE_APPEND | LOCK_EX);
   // Remove contrib theme after theme generation.
   shell_exec ("rm -rf web/themes/contrib/emulsify-drupal/");
-  shell_exec ("sed -i.bak 's/sous-project/$composerRoot/g' .lando.yml && rm -f .lando.yml.bak");
+  shell_exec ("sed -i.bak 's/sous-project/$dashed_project_name/g' .lando.yml && rm -f .lando.yml.bak");
   }
 }

--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -20,12 +20,13 @@ public static function installTheme() {
   // New DrupalFinder to get the Composer root path.
   $drupalFinder = new DrupalFinder();
   $drupalFinder->locateRoot(getcwd());
-  $unsafeChars = array(".", " ");
-  $spacingChars = array("-", "_");
+  $unsafeChars = array(".", "!", "=", "|", "<", ">", "/");
+  $spacingChars = array("-", "_", " ");
   $composerRoot = str_replace($unsafeChars, '', strtolower(basename($drupalFinder->getComposerRoot())));
+  // EmulsifyCLI strips out all unsafe and spacing chars when generating
+  // the theme. We need to replicate this output.
   $emulsify_project_name = str_replace($spacingChars, '', $composerRoot);
-  $underscored_project_name = str_replace('-', '_', $composerRoot);
-  $dashed_project_name = str_replace('_', '-', $composerRoot);
+  $dashed_project_name = str_replace(' ','-', str_replace('_', '-', $composerRoot));
   // Install node dependencies which include EmulsifyCLI for commands below.
   shell_exec ('[ -s "$HOME/.nvm/nvm.sh" ] && . "$HOME/.nvm/nvm.sh" && nvm install lts/gallium && nvm use && npm ci');
   // Execute the Emulsify theme build based on composer create path.
@@ -33,12 +34,12 @@ public static function installTheme() {
   shell_exec ("[ -s \"\$HOME/.nvm/nvm.sh\" ] && . \"\$HOME/.nvm/nvm.sh\" && nvm install lts/gallium && nvm use && cd web/themes/custom/$emulsify_project_name/ && npx emulsify system install compound");
   // Generate  system.theme.yml and append new theme to install.
   $system_theme_yml = [
-    "default" => $underscored_project_name,
+    "default" => $emulsify_project_name,
     "admin"=> "gin"
   ];
   $yaml = Yaml::dump($system_theme_yml);
   file_put_contents('web/profiles/contrib/sous/config/install/system.theme.yml', $yaml);
-  file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$underscored_project_name.PHP_EOL, FILE_APPEND | LOCK_EX);
+  file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$emulsify_project_name.PHP_EOL, FILE_APPEND | LOCK_EX);
   // Remove contrib theme after theme generation.
   shell_exec ("rm -rf web/themes/contrib/emulsify-drupal/");
   shell_exec ("sed -i.bak 's/sous-project/$dashed_project_name/g' .lando.yml && rm -f .lando.yml.bak");

--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -37,6 +37,6 @@ public static function installTheme() {
   file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$composerRoot.PHP_EOL, FILE_APPEND | LOCK_EX);
   // Remove contrib theme after theme generation.
   shell_exec ("rm -rf web/themes/contrib/emulsify-drupal/");
-  shell_exec ("sed -i '' 's/sous-project/$composerRoot/g' .lando.yml");
+  shell_exec ("sed -i.bak 's/sous-project/$composerRoot/g' .lando.yml && rm -f .lando.yml.bak");
   }
 }


### PR DESCRIPTION
### Purpose:
- Simplify the install process by automatically updating the lando site name and default config folder. Fixes this process for linux-based OS's.


### Testing:
- Run the following command on MacOS and Linux-based OS: `composer create-project fourkitchens/sous-drupal-project:dev-fix-sed-command-for-linux super-awesome-drupal-site --no-interaction` and confirm there are no errors returned. 
- [x] Review your `.lando.yml` file and verify the `name: super_awesome-drupal-site` and the `DRUSH_OPTIONS_URI: "https://super-awesome-drupal-site.lndo.site"` are present.