### PR TITLE
fix: adds oomphinc to allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
             "zaporylie/composer-drupal-optimizations": true
+            "oomphinc/composer-installers-extender": true
         }
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
             "cweagans/composer-patches": true,
             "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
-            "zaporylie/composer-drupal-optimizations": true
+            "zaporylie/composer-drupal-optimizations": true,
             "oomphinc/composer-installers-extender": true
         }
     },


### PR DESCRIPTION
### Purpose:
To include oomphinc to the allow-plugins tree in composer.json.

### Testing:
Create the project as you normally would with `composer create-project`. You should no longer see the following during the creation process:
```
oomphinc/composer-installers-extender contains a Composer plugin which is b  
 locked by your allow-plugins config. You may add it to the list if you cons  
 ider it safe.                                 
 You can run "composer config --no-plugins allow-plugins.oomphinc/composer-i  
 nstallers-extender [true|false]" to enable it (true) or disable it explicit  
 ly and suppress this exception (false)                    
 See https://getcomposer.org/allow-plugins
```