### PR TITLE
fix: remove drupal console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "fourkitchens/sous-drupal-distro": "dev-4.x-beta",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",
-        "drupal/console": "^1.9.7",
         "drupal/core-recommended": "^9",
         "drupal/core-composer-scaffold": "^9",
         "drush/drush": "^10.0",
@@ -41,9 +40,9 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
-            "zaporylie/composer-drupal-optimizations": true
+            "zaporylie/composer-drupal-optimizations": true,
+            "oomphinc/composer-installers-extender": false
         }
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
-            "zaporylie/composer-drupal-optimizations": true,
-            "oomphinc/composer-installers-extender": false
+            "zaporylie/composer-drupal-optimizations": true
         }
     },
     "autoload": {


### PR DESCRIPTION
### Purpose
To remove the drupal/console dependency composer.json since it is no longer used.

### Testing
- [ ] run `composer install`
- [ ] Monitor for Drupal Console errors during the process and check your folder structure for Drupal Console. You should not find anything related to Drupal Console.