### PR TITLE
Add database password instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ lando start
 - Boot local environment and install `Lando start`
 
   - Follow URL once environment is booted and proceed with Drupal Install
+  - Please note, when installing the database you must enter "drupal9" as the password on the install screen.
 
 - Create config directories and set path in settings.php
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ lando start
 - Boot local environment and install `Lando start`
 
   - Follow URL once environment is booted and proceed with Drupal Install
-  - Please note, when installing the database you must enter "drupal9" as the password on the install screen.
+  - Please note, when installing the database you must enter "drupal9" as the password on the install screen to proceed.
 
 - Create config directories and set path in settings.php
 


### PR DESCRIPTION
### Purpose
Add instructions to let the user know that they need to manually type in the "drupal9" password in order to install the database.

### Testing

- [x] Checkout and read over line 36 of the readme and make sure it is clear and makes sense.