### PR TITLE
3325717: Setup settings.local.php and scaffold it during initial install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,6 @@
                 "sites/default/example.settings.my.php"
             ],
             "file-mapping": {
-                "[web-root]/.gitattributes": "web/core/assets/scaffold/files/gitattributes",
                 "[web-root]/sites/default/settings.local.php": {
                     "mode": "replace",
                     "path": "web/core/assets/scaffold/files/example.settings.local.php",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=7.4",
         "fourkitchens/sous-drupal-distro": "4.x-dev",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "fourkitchens/sous-drupal-distro": "4.x-dev",
         "drupal/config_direct_save": "^1.0",
         "cweagans/composer-patches": "^1.6.5",
@@ -98,14 +98,13 @@
             "includes": [
                 "sites/default/example.settings.my.php"
             ],
-            "initial": {
-                ".eslintignore": ".eslintignore",
-                ".eslintrc.json": ".eslintrc.json",
-                ".gitattributes": ".gitattributes",
-                ".htaccess": ".htaccess",
-                "robots.txt": "robots.txt",
-                "sites/example.settings.local.php": "sites/example.settings.local.php",
-                "sites/example.sites.php": "sites/example.sites.php"
+            "file-mapping": {
+                "[web-root]/.gitattributes": "web/core/assets/scaffold/files/gitattributes",
+                "[web-root]/sites/default/settings.local.php": {
+                    "mode": "replace",
+                    "path": "web/core/assets/scaffold/files/example.settings.local.php",
+                    "overwrite": false
+                }
             },
             "omit-defaults": false
         }


### PR DESCRIPTION
**Purpose**
- Sets up composer.json to use the `file-mapping` rather than the old `initial` key.
- Removes all line entries that `core-composer-scaffold` copies over by default.
- Adds new entry to copy over example settings to local settings. This is set up as `overwrite: false` so it is not overwritten once it is configured.

**DO Issue**
[https://www.drupal.org/project/sous/issues/3325717](https://www.drupal.org/project/sous/issues/3325717)

**Functional Testing**
- Checkout this branch.
- Perform a composer install e.g. `lando composer install`
- Ensure proper files are copied over.
- Edit the settings.local.php file.
- Run composer install again
- Recognize that the settings.local.php file is not overwritten.