### PR TITLE
Settings scaffold

### DIFF
--- a/assets/scaffold/files/additions-default.settings.txt
+++ b/assets/scaffold/files/additions-default.settings.txt
@@ -3,3 +3,9 @@
  */
 $settings['config_sync_directory'] = '../config/default';
 
+/**
+ * Load local development override configuration.
+ */
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}

--- a/assets/scaffold/files/additions-example.settings.local.txt
+++ b/assets/scaffold/files/additions-example.settings.local.txt
@@ -1,0 +1,19 @@
+/**
+ * Salt for one-time login links, cancel links, form tokens, etc.
+ */
+$settings['hash_salt'] = 'local';
+
+/*
+ * Local database configuration.
+ */
+$databases['default']['default'] = array (
+  'database' => 'drupal9',
+  'username' => 'drupal9',
+  'password' => 'drupal9',
+  'prefix' => '',
+  'host' => 'database',
+  'port' => '3306',
+  'namespace' => 'Drupal\\mysql\\Driver\\Database\\mysql',
+  'driver' => 'mysql',
+  'autoload' => 'core/modules/mysql/src/Driver/Database/mysql/',
+);

--- a/composer.json
+++ b/composer.json
@@ -147,9 +147,12 @@
                 "sites/default/example.settings.my.php"
             ],
             "file-mapping": {
+                "[web-root]/sites/example.settings.local.php": {
+                    "append": "assets/scaffold/files/additions-example.settings.local.txt"
+                },
                 "[web-root]/sites/default/settings.local.php": {
                     "mode": "replace",
-                    "path": "web/core/assets/scaffold/files/example.settings.local.php",
+                    "path": "web/sites/example.settings.local.php",
                     "overwrite": false
                 },
                 "[web-root]/sites/default/default.settings.php": {

--- a/composer.json
+++ b/composer.json
@@ -150,11 +150,6 @@
                 "[web-root]/sites/example.settings.local.php": {
                     "append": "assets/scaffold/files/additions-example.settings.local.txt"
                 },
-                "[web-root]/sites/default/settings.local.php": {
-                    "mode": "replace",
-                    "path": "web/sites/example.settings.local.php",
-                    "overwrite": false
-                },
                 "[web-root]/sites/default/default.settings.php": {
                     "append": "assets/scaffold/files/additions-default.settings.txt"
                 },
@@ -168,6 +163,7 @@
         }
     },
     "scripts": {
+        "post-drupal-scaffold-cmd": "cp web/sites/example.settings.local.php web/sites/default/settings.local.php",
         "post-create-project-cmd": "Sous\\Starter::installTheme"
     }
 }

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,1 @@
+/README.md

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,1 +1,0 @@
-/README.md


### PR DESCRIPTION
- Adds new additions file that includes a hash salt and db credentials for local development.
- Updates composer file-mapping scaffolding to append database credentials and hash salt.
- Updates composer file-mapping to copy example.settings.local.php to settings.local.php.
- Updates additions file for default.settings.php to include file_exists code block so out of the box our local settings file will be used.

NOTES:
- I added the hash salt because I received a hash salt missing error.
- We are successfully appending database credentials to `example.settings.local.php` during scaffolding. However this file is scaffolded to `web/sites/example.settings.local.php`. When trying to scaffold `example.settings.local.php` to `settings.local.php`, I would get an error stating the file at `web/sites/example.settings.local.php` does not exist. 
- This is what I had that was throwing the error.
```
                "[web-root]/sites/example.settings.local.php": {
                    "append": "assets/scaffold/files/additions-example.settings.local.txt"
                },
                "[web-root]/sites/default/settings.local.php": {
                    "mode": "replace",
                    "path": "web/sites/example.settings.local.php",
                    "overwrite": false
                }
```
- After trying a few things that didn't work, I ended up removing the second code block leaving just the append block and added a post scaffold command that copies `example.settings.local.php` to `web/sites/default/settings.local.php`. I guess we can't scaffold files from the `web` directory.
- During site install you will still need to plug in the database name, username, password, and host. After submitting you should be taken to a page that says your site is already installed.