### PR TITLE
Cleanup of Gin Theme integration PR

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -17,6 +17,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  gin_toolbar: 0
   image: 0
   inline_form_errors: 0
   jquery_ui: 0

--- a/config/default/gin.settings.yml
+++ b/config/default/gin.settings.yml
@@ -1,16 +1,23 @@
-_core:
-  default_config_hash: UvSCt3S_NldJPFzvhSNOy9vWoPPFhmsmTC12vtVss9s
-preset_accent_color: blue
-preset_focus_color: gin
-enable_darkmode: '0'
-classic_toolbar: vertical
-secondary_toolbar_frontend: true
+favicon:
+  use_default: true
+features:
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: true
+  node_user_picture: false
 logo:
   use_default: true
-high_contrast_mode: false
-layout_density: default
-show_description_toggle: false
-show_user_theme_settings: false
 third_party_settings:
   shortcut:
     module_link: true
+preset_accent_color: green
+preset_focus_color: gin
+enable_darkmode: '0'
+classic_toolbar: horizontal
+secondary_toolbar_frontend: true
+high_contrast_mode: false
+accent_color: ''
+focus_color: ''
+layout_density: default
+show_description_toggle: true
+show_user_theme_settings: false

--- a/sous/Starter.php
+++ b/sous/Starter.php
@@ -32,14 +32,6 @@ public static function installTheme() {
   // Execute the Emulsify theme build based on composer create path.
   shell_exec ("[ -s \"\$HOME/.nvm/nvm.sh\" ] && . \"\$HOME/.nvm/nvm.sh\" && nvm install lts/gallium && nvm use && npx emulsify init $emulsify_project_name --platform drupal");
   shell_exec ("[ -s \"\$HOME/.nvm/nvm.sh\" ] && . \"\$HOME/.nvm/nvm.sh\" && nvm install lts/gallium && nvm use && cd web/themes/custom/$emulsify_project_name/ && npx emulsify system install compound");
-  // Generate  system.theme.yml and append new theme to install.
-  $system_theme_yml = [
-    "default" => $emulsify_project_name,
-    "admin"=> "gin"
-  ];
-  $yaml = Yaml::dump($system_theme_yml);
-  file_put_contents('web/profiles/contrib/sous/config/install/system.theme.yml', $yaml);
-  file_put_contents('web/profiles/contrib/sous/sous.info.yml', '  - '.$emulsify_project_name.PHP_EOL, FILE_APPEND | LOCK_EX);
   // Remove contrib theme after theme generation.
   shell_exec ("rm -rf web/themes/contrib/emulsify-drupal/");
   shell_exec ("sed -i.bak 's/sous-project/$dashed_project_name/g' .lando.yml && rm -f .lando.yml.bak");


### PR DESCRIPTION
- Enables Gin Toolbar so the FE theme is consistent with the Admin theme
- Removed references to the old sous-profile during the theme-setup step
- Set some reasonable Gin settings for horizontal toolbar and 4K green accent

## Testing:
- run `composer create-project fourkitchens/sous-drupal-project:dev-remove-profile-set-gin-admin-theme-cleanup test-sous-remove --no-interaction --ignore-platform-reqs` 
- Once the above is complete `cd` into your new project directory and run `lando start`
- Verify you can go through the entire Drupal install process without error
- Verify you can see the Gin Toolbar while viewing the FE theme
- Verify the toolbar is horizontal and green accent color