### PR TITLE
disable composer process timeout and enable media library

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,8 +1,11 @@
-name: sous-project
+name: test-sous-project
 recipe: drupal9
 config:
   webroot: web
   php: "8.1"
+  index: false
+  edge: false
+  cache: false
 services:
   appserver:
     build:
@@ -10,6 +13,9 @@ services:
       - cp web/sites/default/default.settings.php web/sites/default/settings.php
   node:
     type: node:16
+    overrides:
+      ports:
+        - 6006:6006
     build:
       - npm install
       - npm install @emulsify/cli
@@ -17,7 +23,7 @@ tooling:
   drush:
     service: appserver
     env:
-      DRUSH_OPTIONS_URI: "https://sous-project.lndo.site"
+      DRUSH_OPTIONS_URI: "https://test-sous-project.lndo.site"
   npm:
     service: node
   emulsify:
@@ -25,7 +31,7 @@ tooling:
   compound-install:
     service: node
     description: "Install Compound component library"
-    cmd: cd $LANDO_MOUNT && cd web/themes/custom/sous-theme && emulsify system install compound
+    cmd: cd $LANDO_MOUNT && cd web/themes/custom/testsousproject && emulsify system install compound
   sous-builder-install:
     service: appserver
     description: "Install Sous Builder module and theme demo"

--- a/.lando.yml
+++ b/.lando.yml
@@ -35,4 +35,4 @@ tooling:
   sous-builder-install:
     service: appserver
     description: "Install Sous Builder module and theme demo"
-    cmd: composer config repositories.2 git https://github.com/fourkitchens/sous-builder.git && composer config repositories.3 git https://github.com/fourkitchens/sousdemo.git && composer require fourkitchens/sous-builder && composer require fourkitchens/sousdemo && drush pm:enable sous_builder -y
+    cmd: composer config repositories.2 git https://github.com/fourkitchens/sous-builder.git && composer config repositories.3 git https://github.com/fourkitchens/sousdemo.git && composer require fourkitchens/sous-builder && composer require fourkitchens/sousdemo && drush pm:enable sous_builder -y && drush theme:enable sousdemo -y && drush config-set system.theme default sousdemo

--- a/.lando.yml
+++ b/.lando.yml
@@ -35,4 +35,4 @@ tooling:
   sous-builder-install:
     service: appserver
     description: "Install Sous Builder module and theme demo"
-    cmd: composer config repositories.2 git https://github.com/fourkitchens/sous-builder.git && composer require fourkitchens/sous-builder && drush pm:enable sous_builder -y
+    cmd: composer config repositories.2 git https://github.com/fourkitchens/sous-builder.git && composer config repositories.3 git https://github.com/fourkitchens/sousdemo.git && composer require fourkitchens/sous-builder && composer require fourkitchens/sousdemo && drush pm:enable sous_builder -y

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,4 +1,4 @@
-name: test-sous-project
+name: sous-project
 recipe: drupal9
 config:
   webroot: web
@@ -23,7 +23,7 @@ tooling:
   drush:
     service: appserver
     env:
-      DRUSH_OPTIONS_URI: "https://test-sous-project.lndo.site"
+      DRUSH_OPTIONS_URI: "https://sous-project.lndo.site"
   npm:
     service: node
   emulsify:
@@ -31,7 +31,7 @@ tooling:
   compound-install:
     service: node
     description: "Install Compound component library"
-    cmd: cd $LANDO_MOUNT && cd web/themes/custom/testsousproject && emulsify system install compound
+    cmd: cd $LANDO_MOUNT && cd web/themes/custom/sous-theme && emulsify system install compound
   sous-builder-install:
     service: appserver
     description: "Install Sous Builder module and theme demo"

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
             "drupal/core-composer-scaffold": true,
             "zaporylie/composer-drupal-optimizations": true,
             "oomphinc/composer-installers-extender": true
-        }
+        },
+        "process-timeout": 0
     },
     "autoload": {
         "psr-4": {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -42,6 +42,7 @@ module:
   linkit: 0
   login_history: 0
   media: 0
+  media_library: 0
   menu_block: 0
   menu_link_content: 0
   menu_ui: 0

--- a/scripts/sous/setup.sh
+++ b/scripts/sous/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+git config --global init.defaultBranch main
 git init
 lando start
 lando npm --prefix ./ install

--- a/scripts/sous/setup.sh
+++ b/scripts/sous/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 lando start
+lando npm ci
 lando emulsify init sous-project --platform drupal
 lando npm --prefix ./web/themes/custom/sous-project install
 lando compound-install

--- a/scripts/sous/setup.sh
+++ b/scripts/sous/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 lando start
-lando npm ci
+lando npm --prefix ./ install
 lando emulsify init sous-project --platform drupal
 lando npm --prefix ./web/themes/custom/sous-project install
 lando compound-install

--- a/scripts/sous/setup.sh
+++ b/scripts/sous/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+git init
 lando start
 lando npm --prefix ./ install
 lando emulsify init sous-project --platform drupal


### PR DESCRIPTION
- disable composer process timeout
- enable media library, which we should use instead of entity builder for media
- add npm install at beginning of sous setup script

Disable composer process timeout is because while running the sous setup script from the remove-profile-legacy-modules branch, I got this error:

<img width="607" alt="sous-setup-script" src="https://user-images.githubusercontent.com/1652730/232438149-da071441-f167-4c14-800a-5ea88aaf72df.png">

Note: I am seeing an error with husky when running npm install

<img width="562" alt="husky-fail" src="https://user-images.githubusercontent.com/1652730/232451284-5c00576e-13a7-4120-8711-fad53173505b.png">

I'm getting this error with the emulisify init step:

<img width="831" alt="emulsify-init-fail" src="https://user-images.githubusercontent.com/1652730/232489653-fe598a1f-0568-468c-b856-096d2b219ac2.png">

It fails after this step (continues to run but a lot of npm errors). But if I cd into the directory and run the steps that are in that script manually, it works. 

Test using:

Run the following command to setup your new Drupal site - `composer create-project fourkitchens/sous-drupal-project:dev-remove-profile-legacy-modules-timeout test-sous-project --no-interaction --ignore-platform-reqs`
Run` lando sous-builder-install `and verify the module installs and is enabled
Go to https://test-sous-project.lndo.site and verify you see welcome landing page
