### PR TITLE
feat: Add patches for field validation when tabs are on edit form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,12 @@
                 }
             },
             "omit-defaults": false
+        },
+        "patches": {
+            "drupal/field_group": {
+                "2969051 - HTML5 Validation Prevents Submission in Tabs": "https://www.drupal.org/files/issues/2023-04-24/2969051-99.patch",
+                "2787179 - Ensure visibility of invalid fields (JS)": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
## Ticket
[Issue](https://www.drupal.org/project/sous/issues/3347277)

## Testing:

- [x] Run `composer create-project fourkitchens/sous-drupal-project:dev-issue-3347277-Add-patches test --no-interaction` 
- [x] Run `cd test && composer install && lando rebuild`.
- [x] Go to `/admin/appearance` and changes theme admin to Gin. 
- [x] Go to `/admin/modules` and enable module "field group".
- [x] Go to any form (content type) and add two fields, one required and one **not** required. Add those fields into a new group "tab".
- [x] When you create a node, you should try to save empty, now you can see the error.

