### PR TITLE
3377848-remove-media-entity

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -19,11 +19,9 @@ module:
   dropzonejs: 0
   dynamic_page_cache: 0
   editor: 0
-  entity_browser: 0
-  entity_browser_enhanced: 0
-  entity_embed: 0
   embed: 0
   emulsify_twig: 0
+  entity_embed: 0
   entity_reference_revisions: 0
   entity_usage: 0
   field: 0

--- a/config/default/editor.editor.full_html.yml
+++ b/config/default/editor.editor.full_html.yml
@@ -19,6 +19,7 @@ settings:
       - subscript
       - '|'
       - link
+      - drupalMedia
       - '|'
       - bulletedList
       - numberedList
@@ -36,6 +37,8 @@ settings:
       startIndex: true
     media_media:
       allow_view_mode_override: false
+    linkit_extension:
+      linkit_enabled: false
 image_upload:
   status: true
   scheme: public

--- a/config/default/filter.format.full_html.yml
+++ b/config/default/filter.format.full_html.yml
@@ -3,11 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.media.full
+    - core.entity_view_mode.media.media_library
   module:
-    1: editor
-    2: entity_embed
-    3: media
+    - editor
+    - entity_embed
+    - media
 name: 'Full HTML'
 format: full_html
 weight: 2
@@ -44,9 +44,11 @@ filters:
     settings:
       default_view_mode: default
       allowed_view_modes:
-        full: full
+        media_library: media_library
       allowed_media_types:
+        file: file
         image: image
+        video: video
   entity_embed:
     id: entity_embed
     provider: entity_embed

--- a/config/default/user.role.superuser.yml
+++ b/config/default/user.role.superuser.yml
@@ -14,7 +14,6 @@ dependencies:
     - crop
     - dropzonejs
     - embed
-    - entity_browser
     - entity_reference_revisions
     - entity_usage
     - field_ui
@@ -68,7 +67,6 @@ permissions:
   - 'administer crop types'
   - 'administer display modes'
   - 'administer embed buttons'
-  - 'administer entity browsers'
   - 'administer entity usage'
   - 'administer filters'
   - 'administer image styles'


### PR DESCRIPTION
DO Issue: https://www.drupal.org/project/sous/issues/3377848

The entity browsers appeared to already be removed. So I uninstalled the entity_browser modules and enabled and did a basic config for core media library. Let me know if there is a particular way you want this configured.