### PR TITLE
Install issue with nodesource.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -20,8 +20,8 @@ services:
     build_as_root:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
-      - sudo apt-get install -y ca-certificates curl gnupg
-      - sudo mkdir -p /etc/apt/keyrings
+      - apt-get install -y ca-certificates curl gnupg
+      - mkdir -p /etc/apt/keyrings
       - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       - NODE_MAJOR=16
       - apt-get install -qq -y nodejs

--- a/.lando.yml
+++ b/.lando.yml
@@ -20,9 +20,6 @@ services:
     build_as_root:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
-      - apt-get install -y ca-certificates curl gnupg
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
-      - NODE_MAJOR=16
       - apt-get install -qq -y nodejs
       - chown -R www-data /usr/lib/node_modules
       - chown -R www-data /usr/bin

--- a/.lando.yml
+++ b/.lando.yml
@@ -22,7 +22,7 @@ services:
       - apt-get install -qq chromium
       - sudo apt-get install -y ca-certificates curl gnupg
       - sudo mkdir -p /etc/apt/keyrings
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
       - NODE_MAJOR=16
       - apt-get install -qq -y nodejs
       - chown -R www-data /usr/lib/node_modules

--- a/.lando.yml
+++ b/.lando.yml
@@ -21,8 +21,7 @@ services:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
       - apt-get install -y ca-certificates curl gnupg
-      - mkdir -p /etc/apt/keyrings
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | bash -
       - NODE_MAJOR=16
       - apt-get install -qq -y nodejs
       - chown -R www-data /usr/lib/node_modules

--- a/.lando.yml
+++ b/.lando.yml
@@ -21,7 +21,7 @@ services:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
       - apt-get install -y ca-certificates curl gnupg
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | bash -
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
       - NODE_MAJOR=16
       - apt-get install -qq -y nodejs
       - chown -R www-data /usr/lib/node_modules

--- a/.lando.yml
+++ b/.lando.yml
@@ -23,7 +23,7 @@ services:
       - apt-get update
       - apt-get install -y ca-certificates curl gnupg
       - mkdir -p /etc/apt/keyrings
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --no-tty --dearmor -o /etc/apt/keyrings/nodesource.gpg
       - NODE_MAJOR=20
       - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
       - apt-get update

--- a/.lando.yml
+++ b/.lando.yml
@@ -23,9 +23,8 @@ services:
       - apt-get update
       - apt-get install -y ca-certificates curl gnupg
       - mkdir -p /etc/apt/keyrings
-      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --no-tty --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      - NODE_MAJOR=20
-      - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
       - apt-get update
       - apt-get install nodejs -y
       - chown -R www-data /usr/lib/node_modules

--- a/.lando.yml
+++ b/.lando.yml
@@ -20,7 +20,14 @@ services:
     build_as_root:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
-      - apt-get install -qq -y nodejs
+      - apt-get update
+      - apt-get install -y ca-certificates curl gnupg
+      - mkdir -p /etc/apt/keyrings
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - NODE_MAJOR=20
+      - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+      - apt-get update
+      - apt-get install nodejs -y
       - chown -R www-data /usr/lib/node_modules
       - chown -R www-data /usr/bin
       - npm install --silent -g npm

--- a/.lando.yml
+++ b/.lando.yml
@@ -24,12 +24,12 @@ services:
       - apt-get install -y ca-certificates curl gnupg
       - mkdir -p /etc/apt/keyrings
       - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+      - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
       - apt-get update
       - apt-get install nodejs -y
       - chown -R www-data /usr/lib/node_modules
       - chown -R www-data /usr/bin
-      - npm install --silent -g npm
+      - npm install --silent -g npm@latest
       - npm install --silent -g @emulsify/cli
 tooling:
   drush:

--- a/.lando.yml
+++ b/.lando.yml
@@ -20,7 +20,10 @@ services:
     build_as_root:
       - apt-get update -qq -y && apt-get install -qq -y apt-transport-https build-essential unzip
       - apt-get install -qq chromium
-      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      - sudo apt-get install -y ca-certificates curl gnupg
+      - sudo mkdir -p /etc/apt/keyrings
+      - curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      - NODE_MAJOR=16
       - apt-get install -qq -y nodejs
       - chown -R www-data /usr/lib/node_modules
       - chown -R www-data /usr/bin


### PR DESCRIPTION
[Issue](https://www.drupal.org/project/sous/issues/3385967)
[Error](https://app.warp.dev/block/bzLalVWjtgpM39K9tXHsVw)

Nodesource Node have new features and now the 
_Installation Scripts: The installation scripts setup_XX.x are no longer supported and are not needed anymore, as the installation process is straightforward for any RPM and DEB distro._

So I change the way to install this according to the new propose mentioned in their repo readme.