### PR TITLE
fix: update setup theme label

### DIFF
--- a/scripts/sous/setup.sh
+++ b/scripts/sous/setup.sh
@@ -12,7 +12,7 @@ echo "Creating an Emulsify based theme..."
 lando drush emulsify sous-project
 echo "Installing theme dependencies... This may take a minute..."
 lando npm --prefix ./web/themes/custom/sous-project install --silent
-echo "Enable sousdrupalrecipe set as the default theme..."
+echo "Enable sous-project and set as the default theme..."
 lando drush theme:install sous-project
 lando drush config-set system.theme default sous-project -y
 lando drush user:block superuser_1


### PR DESCRIPTION
**This PR does the following:**
- Corrects the setup scripts label for the custom theme it generates

### Functional Testing:
- [ ] Run `composer create-project fourkitchens/sous-drupal-project callinmullaney`
- [ ] Verify the setup script outputs "Enable callinmullaney and set as the default theme..." instead of "Enable sousdrupalrecipe set as the default theme..."