### PR TITLE
fix: Remove dev repos for the new version of Emulsify

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/woredeyonas/Drupal-Recipe-Unpack.git"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:emulsify-ds/emulsify-drupal.git"
-        },
-        {
-            "type": "vcs",
-            "url": "git@github.com:emulsify-ds/emulsify_tools.git"
         }
     ],
     "require": {


### PR DESCRIPTION
**This PR does the following:**
- Removes git repository references to Emulsify dev versions. This is now installed/handled by the Sous-Emulsify recipe - https://github.com/fourkitchens/sous-emulsify