### PR TITLE
feat: Allow theme-build command to fail gracefully

### DIFF
--- a/scripts/sous/theme-build.sh
+++ b/scripts/sous/theme-build.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
-cd web/themes/custom/sous-project
-npm ci
-npm run storybook-build
+# Theme directories this script needs to build.
+SRC_DIR="web/themes/custom/sous-project/src"
+COMPONENTS_DIR="web/themes/custom/sous-project/components"
+
+# Check if either of the directories exists
+if [ -d "$SRC_DIR" ] || [ -d "$COMPONENTS_DIR" ]; then
+  cd web/themes/custom/sous-project
+  npm ci
+  npm run storybook-build
+else
+  echo "Cannot find components to compile within the sous-project theme. Skipping build step."
+fi


### PR DESCRIPTION
**This PR does the following:**
During the initial project setup it's typical to also setup the CI process. This process triggers the `npm run theme-build` command for remote environments. However, the project doesn't yet have a component library installed so any theme-build attempts cause a failure.

### Functional Testing:
- [ ] Run `composer create-project fourkitchens/sous-drupal-project theme-build-test` - choose any setup option
- [ ] Immediately after this process completes run `cd theme-build-test && nvm use && npm run theme-build` - verify this fails
- [ ] Run `composer create-project fourkitchens/sous-drupal-project:dev-feat-theme-build-fail-graceful theme-build-test-2`
- [ ] Immediately after this process completes run `cd theme-build-test-2 && nvm use && npm run theme-build` - verify this skips the build step with a message.
