### PR TITLE
fix: remove field_group patch because it has been merged

### DIFF
--- a/patches/composer.patches.json
+++ b/patches/composer.patches.json
@@ -1,8 +1,7 @@
 {
   "patches": {
     "drupal/field_group": {
-      "2969051 - HTML5 Validation Prevents Submission in Tabs": "https://www.drupal.org/files/issues/2024-08-09/2969051-148.patch",
-      "2787179 - Ensure visibility of invalid fields (JS)": "https://git.drupalcode.org/project/field_group/-/merge_requests/6.diff"
+      "2969051 - HTML5 Validation Prevents Submission in Tabs": "https://www.drupal.org/files/issues/2024-08-09/2969051-148.patch"
     }
   }
 }


### PR DESCRIPTION
**This PR does the following:**
- This patch has been rolled into the latest release of field_group and no longer applies