### PR TITLE
SOUS-60: DDEV NPM error when installing Emulsify Theme

### DIFF
--- a/.ddev/commands/web/emulsify
+++ b/.ddev/commands/web/emulsify
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## Description: Run Emulsify CLI inside the web container
+## Usage: emulsify [flags] [args]
+## Example: "ddev emulsify system list" or "ddev emulsify system install emulsify-ui-kit"
+## HostWorkingDir: true
+## ExecRaw: true
+
+
+if ! command -v emulsify >/dev/null; then
+  echo "emulsify is not available. You may need to 'ddev npm install -g @emulsify/cli'"
+  exit 1
+fi
+emulsify "$@"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,6 +16,9 @@ corepack_enable: false
 nodejs_version: "20"
 hooks:
     post-start:
+        - exec: sudo dpkg --add-architecture amd64
+        - exec: sudo apt-get update
+        - exec: sudo apt-get install -y libc6:amd64 libstdc++6:amd64 zlib1g:amd64
         - exec: sudo npm install --silent -g npm@latest
         - exec: sudo npm install --silent -g @emulsify/cli
 


### PR DESCRIPTION
**This PR does the following:**
- Closes #121 
- Fixes DDEV architecture
- Adds DDEV support for emulsify-cli command

### Ticket(s)

- [SOUS-60: DDEV NPM error when installing Emulsify Theme](https://app.clickup.com/t/36718269/SOUS-60)

### Functional Testing:

- [ ] Create a new project using this branch
- [ ] Confirm `ddev npm install` Emulsify dependencies works as expected
- [ ] Once the site is installed, navigate to the new theme folder and confirm you can run `ddev emulsify system install emulsify-ui-kit` or `ddev emulsify system install compound`
